### PR TITLE
Fix for backuptool not run

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -4376,7 +4376,7 @@ endif
 ifeq ($(WITH_GMS),true)
     $(INTERNAL_OTA_PACKAGE_TARGET): backuptool := false
 else
-ifneq ($(POTATO_BUILD),)
+ifneq ($(XTENDED_BUILD),)
     $(INTERNAL_OTA_PACKAGE_TARGET): backuptool := true
 else
     $(INTERNAL_OTA_PACKAGE_TARGET): backuptool := false


### PR DESCRIPTION
This commit fixed the lack of reinstalling magisk and gaps after updating ROM