### PR TITLE
releasetools: Support erofs on non-dynamic partitions

### DIFF
--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -3450,7 +3450,8 @@ PARTITION_TYPES = {
     "ext4": "EMMC",
     "emmc": "EMMC",
     "f2fs": "EMMC",
-    "squashfs": "EMMC"
+    "squashfs": "EMMC",
+    "erofs": "EMMC"
 }
 
 


### PR DESCRIPTION
This it's required on some devices using erofs as system partition.

Change-Id: Ibeb228132d3c0cc1d7407c2a40498b72580c81d5